### PR TITLE
Generic NeuralNetworks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,8 +34,15 @@ name = "dnn_rs"
 version = "0.1.0"
 dependencies = [
  "approx",
+ "dyn-clone",
  "nalgebra",
 ]
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
 
 [[package]]
 name = "getrandom"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2021"
 [dependencies]
 nalgebra = { version = "0.32.5", features = ["rand"] }
 approx = "0.5.1"
+dyn-clone = "1.0.0"

--- a/examples/simple_mlp.rs
+++ b/examples/simple_mlp.rs
@@ -1,6 +1,6 @@
-use dnn_rs::nn::model::NeuralNetwork;
+use dnn_rs::nn::model::{SequentialNeuralNetwork, NeuralNetwork};
 use dnn_rs::nn::activation::{ReLU, Sigmoid, ActivationFunction};
-use dnn_rs::nn::layers::Linear;
+use dnn_rs::nn::layers::{Linear, Layer};
 use dnn_rs::nn::loss::{CrossEntropy, MSE};
 
 use dnn_rs::optim::sgd::SGD;
@@ -16,11 +16,11 @@ fn main() {
 
 
 
-    let layers = vec![Box::new(linear1), Box::new(linear2)];
+    let layers: Vec<Box<dyn Layer>> = vec![Box::new(linear1), Box::new(linear2)];
     let activations: Vec<Box<dyn ActivationFunction>>  = vec![Box::new(activation1), Box::new(activation2)];
     let loss = Box::new(CrossEntropy::new());
 
-    let model = NeuralNetwork::new(layers, activations, loss);
+    let model = SequentialNeuralNetwork::new(layers, activations, loss);
     let lr = 0.01;
     let beta = 0.0;
     let mut optim = SGD::new(model, lr, beta); // Give ownership of model to optim

--- a/examples/simple_mlp.rs
+++ b/examples/simple_mlp.rs
@@ -1,11 +1,11 @@
 use dnn_rs::nn::model::NeuralNetwork;
 use dnn_rs::nn::activation::{ReLU, Sigmoid, ActivationFunction};
-use dnn_rs::nn::layers::Linear;
+use dnn_rs::nn::layers::{Linear, Layer};
 use dnn_rs::nn::loss::{CrossEntropy, MSE};
 
 use dnn_rs::optim::sgd::SGD;
 
-use nalgebra::{DMatrix};
+use nalgebra::DMatrix;
 
 fn main() {
     // Create a simple neural network model
@@ -16,7 +16,7 @@ fn main() {
 
 
 
-    let layers = vec![Box::new(linear1), Box::new(linear2)];
+    let layers: Vec<Box<dyn Layer>>  = vec![Box::new(linear1), Box::new(linear2)];
     let activations: Vec<Box<dyn ActivationFunction>>  = vec![Box::new(activation1), Box::new(activation2)];
     let loss = Box::new(CrossEntropy::new());
 

--- a/examples/simple_mlp.rs
+++ b/examples/simple_mlp.rs
@@ -1,11 +1,11 @@
 use dnn_rs::nn::model::NeuralNetwork;
 use dnn_rs::nn::activation::{ReLU, Sigmoid, ActivationFunction};
-use dnn_rs::nn::layers::{Linear, Layer};
+use dnn_rs::nn::layers::Linear;
 use dnn_rs::nn::loss::{CrossEntropy, MSE};
 
 use dnn_rs::optim::sgd::SGD;
 
-use nalgebra::DMatrix;
+use nalgebra::{DMatrix};
 
 fn main() {
     // Create a simple neural network model
@@ -16,7 +16,7 @@ fn main() {
 
 
 
-    let layers: Vec<Box<dyn Layer>>  = vec![Box::new(linear1), Box::new(linear2)];
+    let layers = vec![Box::new(linear1), Box::new(linear2)];
     let activations: Vec<Box<dyn ActivationFunction>>  = vec![Box::new(activation1), Box::new(activation2)];
     let loss = Box::new(CrossEntropy::new());
 

--- a/src/nn/activation.rs
+++ b/src/nn/activation.rs
@@ -24,7 +24,7 @@
     *
 **/
 
-use nalgebra::{DMatrix};
+use nalgebra::DMatrix;
 use std::f64::consts;
 
 

--- a/src/nn/activation.rs
+++ b/src/nn/activation.rs
@@ -26,10 +26,11 @@
 
 use nalgebra::DMatrix;
 use std::f64::consts;
+use dyn_clone::DynClone;
 
 
 /// Generic trait for activation functions. Defines the forward and backward methods.
-pub trait ActivationFunction {
+pub trait ActivationFunction: DynClone {
     /// Applies the activation function to the input matrix `Z`.
     fn forward(&mut self, Z: &DMatrix<f64>) -> DMatrix<f64>;
 
@@ -37,10 +38,14 @@ pub trait ActivationFunction {
     fn backward(&self, dLdA: &DMatrix<f64>) -> DMatrix<f64>;
 }
 
+dyn_clone::clone_trait_object!(ActivationFunction);
+
 // Identity Activation Function
+#[derive(Clone)]
 pub struct Identity {
     A: DMatrix<f64>,
 }
+
 
 impl Identity {
     pub fn new() -> Self {
@@ -62,6 +67,7 @@ impl ActivationFunction for Identity {
 }
 
 // ReLU Activation Function
+#[derive(Clone)]
 pub struct ReLU {
     A: DMatrix<f64>,
 }
@@ -87,6 +93,7 @@ impl ActivationFunction for ReLU {
 }
 
 // Sigmoid Activation Function
+#[derive(Clone)]
 pub struct Sigmoid {
     A: DMatrix<f64>,
 }
@@ -98,6 +105,7 @@ impl Sigmoid {
         }
     }
 }
+
 
 impl ActivationFunction for Sigmoid {
     fn forward(&mut self, Z: &DMatrix<f64>) -> DMatrix<f64> {
@@ -112,6 +120,7 @@ impl ActivationFunction for Sigmoid {
 }
 
 // Tanh Activation Function
+#[derive(Clone)]
 pub struct Tanh {
     A: DMatrix<f64>,
 }

--- a/src/nn/layers.rs
+++ b/src/nn/layers.rs
@@ -1,4 +1,5 @@
 use nalgebra::DMatrix;
+use dyn_clone::DynClone;
 
 /**
     * Multi-Layer Perceptron (MLP) Layers Module
@@ -15,7 +16,7 @@ use nalgebra::DMatrix;
     *
 **/
 
-pub trait Layer{
+pub trait Layer: DynClone {
     fn forward(&mut self, A : &DMatrix<f64>) -> DMatrix<f64>;
     fn backward(&mut self, dLdZ : &DMatrix<f64>) -> DMatrix<f64>;
     fn get_weights(&self) -> DMatrix<f64>;
@@ -29,6 +30,10 @@ pub trait Layer{
     fn set_weights(&mut self, W : DMatrix<f64>) -> ();
     fn set_bias(&mut self, b : DMatrix<f64>) -> ();
 }
+
+dyn_clone::clone_trait_object!(Layer);
+
+#[derive(Clone)]
 pub struct Linear {
     pub W : DMatrix<f64>, // Weights (C_out x C_in)
     pub b : DMatrix<f64>, // Bias (C_out x 1)

--- a/src/nn/layers.rs
+++ b/src/nn/layers.rs
@@ -1,4 +1,4 @@
-use nalgebra::{DMatrix};
+use nalgebra::DMatrix;
 
 /**
     * Multi-Layer Perceptron (MLP) Layers Module
@@ -15,7 +15,20 @@ use nalgebra::{DMatrix};
     *
 **/
 
+pub trait Layer{
+    fn forward(&mut self, A : &DMatrix<f64>) -> DMatrix<f64>;
+    fn backward(&mut self, dLdZ : &DMatrix<f64>) -> DMatrix<f64>;
+    fn get_weights(&self) -> DMatrix<f64>;
+    fn get_bias(&self) -> DMatrix<f64>;
+    fn get_input(&self) -> DMatrix<f64>;
+    fn get_weight_gradient(&self) -> DMatrix<f64>;
+    fn get_bias_gradient(&self) -> DMatrix<f64>;
+    fn get_batch_size(&self) -> usize;
+    fn get_brod_vec(&self) -> DMatrix<f64>;
 
+    fn set_weights(&mut self, W : DMatrix<f64>) -> ();
+    fn set_bias(&mut self, b : DMatrix<f64>) -> ();
+}
 pub struct Linear {
     pub W : DMatrix<f64>, // Weights (C_out x C_in)
     pub b : DMatrix<f64>, // Bias (C_out x 1)
@@ -40,13 +53,25 @@ impl Linear {
             l_N : DMatrix::zeros(0, 0)
         }
     }
+    // Helpful debug method to print the weights and biases of the layer.
+    pub fn print_layer_params(&self) {
+        println!("Linear Layer Parameters:");
+        println!("Input Features (C_in): {}", self.W.ncols());
+        println!("Output Features (C_out): {}", self.W.nrows());
+        println!("Weights (W):");
+        println!("{:?}", self.W);
+        println!("Biases (b):");
+        println!("{:?}", self.b);
+    }
+}
 
+impl Layer for Linear{
     // During forward propagation, we apply a linear transformation
     // to the incoming data A to obtain output data Z using a weight matrix
     // W and a bias vector b. That is, Z = A * W^T + ι_N * b. The variable
     // ι_N is a column vector of ones of size N (the batch size), and is used
     // to broadcast the bias vector b across all samples in the batch.
-    pub fn forward(&mut self, A : &DMatrix<f64>) -> DMatrix<f64> {
+    fn forward(&mut self, A : &DMatrix<f64>) -> DMatrix<f64> {
         self.N = A.nrows();
         self.A = A.clone();
         self.l_N = DMatrix::from_element(self.N, 1, 1.0);
@@ -60,23 +85,49 @@ impl Linear {
     // ∂L/∂A = ∂L/∂Z * W
     // ∂L/∂W = (∂L/∂Z)^T * A
     // ∂L/∂b = (∂L/∂Z)^T * ι_N
-    pub fn backward(&mut self, dLdZ : &DMatrix<f64>) -> DMatrix<f64> {
+    fn backward(&mut self, dLdZ : &DMatrix<f64>) -> DMatrix<f64> {
         let dLdA = dLdZ * &self.W;
         self.dLdW = dLdZ.transpose() * &self.A;
         self.dLdb = dLdZ.transpose() * &self.l_N;
         return dLdA;
     }
 
-    // Helpful debug method to print the weights and biases of the layer.
-    pub fn print_layer_params(&self) {
-        println!("Linear Layer Parameters:");
-        println!("Input Features (C_in): {}", self.W.ncols());
-        println!("Output Features (C_out): {}", self.W.nrows());
-        println!("Weights (W):");
-        println!("{:?}", self.W);
-        println!("Biases (b):");
-        println!("{:?}", self.b);
+    fn get_weights(&self) -> DMatrix<f64> {
+        self.W.clone() // Return a clone of W
     }
+
+    fn get_bias(&self) -> DMatrix<f64> {
+        self.b.clone()
+    }
+
+    fn get_input(&self) -> DMatrix<f64> {
+        self.A.clone()
+    }
+
+    fn get_weight_gradient(&self) -> DMatrix<f64> {
+        self.dLdW.clone()
+    }
+
+    fn get_bias_gradient(&self) -> DMatrix<f64> {
+        self.dLdb.clone()
+    }
+
+    fn get_batch_size(&self) -> usize {
+        self.N
+    }
+
+    fn get_brod_vec(&self) -> DMatrix<f64> {
+        self.l_N.clone()
+    }
+
+    fn set_weights(&mut self, W : DMatrix<f64>) -> () {
+        self.W = W;
+    }
+
+    fn set_bias(&mut self, b : DMatrix<f64>) -> () {
+        self.b = b;
+    }
+
 }
 
 // Unit tests

--- a/src/nn/loss.rs
+++ b/src/nn/loss.rs
@@ -9,7 +9,7 @@
     * 1. Mean Squared Error (MSE) - L = 1/N * Σ_i (A_i - Y_i)^2
     *
 **/
-use nalgebra::{DMatrix};
+use nalgebra::DMatrix;
 
 // Generic trait for loss functions. Defines the forward and backward methods.
 pub trait LossFunction {

--- a/src/nn/loss.rs
+++ b/src/nn/loss.rs
@@ -10,9 +10,11 @@
     *
 **/
 use nalgebra::DMatrix;
+use dyn_clone::DynClone;
+
 
 // Generic trait for loss functions. Defines the forward and backward methods.
-pub trait LossFunction {
+pub trait LossFunction: DynClone {
     // Computes the loss given the model prediction A and the desired output Y.
     fn forward(&mut self, A: &DMatrix<f64>, Y: &DMatrix<f64>) -> f64;
 
@@ -20,8 +22,12 @@ pub trait LossFunction {
     fn backward(&mut self) -> DMatrix<f64>;
 }
 
+dyn_clone::clone_trait_object!(LossFunction);
 
 // Mean Squared Error Loss
+
+
+#[derive(Clone)]
 pub struct MSE {
     A: DMatrix<f64>, // Model prediction, size N x C
     Y: DMatrix<f64>, // Desired output, size N x C
@@ -77,6 +83,8 @@ impl LossFunction for MSE {
     }
 }
 
+
+#[derive(Clone)]
 pub struct CrossEntropy {
     A: DMatrix<f64>, // Model prediction, size N x C
     Y: DMatrix<f64>, // Desired output, size N x C

--- a/src/nn/model.rs
+++ b/src/nn/model.rs
@@ -1,5 +1,5 @@
 use nalgebra::DMatrix;
-use crate::nn::layers::Layer;
+use crate::nn::layers::{Layer, Linear};
 use crate::nn::loss::LossFunction;
 use crate::nn::activation::ActivationFunction;
 
@@ -23,38 +23,41 @@ use crate::nn::activation::ActivationFunction;
     * where each layer is a linear layer followed by an activation function.
 **/
 
-pub trait NN {
+pub trait NeuralNetwork {
     fn forward(&mut self, x : &DMatrix<f64>) -> DMatrix<f64>;
-    fn backward(&mut self) -> DMatrix<f64>;
+    fn backward(&mut self) -> ();
     fn get_layers(&self) -> Vec<Box<dyn Layer>>;
     fn get_activations(&self) -> Vec<Box<dyn ActivationFunction>>;
     fn get_loss(&self) -> Box<dyn LossFunction>;
 }
-pub struct NeuralNetwork {
+pub struct SequentialNeuralNetwork {
     pub layers: Vec<Box<dyn Layer>>,
     pub activations: Vec<Box<dyn ActivationFunction>>,
     pub loss: Box<dyn LossFunction>,
 }
 
-impl NeuralNetwork {
+impl SequentialNeuralNetwork {
     // Constructor for the NeuralNetwork struct. Creates a new NeuralNetwork
     // model with the specified layers and loss function.
     pub fn new(layers: Vec<Box<dyn Layer>>,
                activations: Vec<Box<dyn ActivationFunction>>,
                loss: Box<dyn LossFunction>) -> Self {
-        NeuralNetwork {
+    SequentialNeuralNetwork {
             layers: layers,
             activations: activations,
             loss: loss,
         }
     }
+}
+
+impl NeuralNetwork for SequentialNeuralNetwork {
 
 
     // During forward propagation, we apply a sequence of linear transformations
     // and activation functions to the input data x to obtain the output data y.
     // That is, y = fNN (x) = fL (fL-1 ( ... f2 (f1 (x)) ... )). The forward
     // method computes the output of the neural network given the input data x.
-    pub fn forward(&mut self, x: &DMatrix<f64>) -> DMatrix<f64> {
+    fn forward(&mut self, x: &DMatrix<f64>) -> DMatrix<f64> {
         let mut A = x.clone();
         for i in 0..self.layers.len() {
             A = self.layers[i].forward(&A);
@@ -75,7 +78,7 @@ impl NeuralNetwork {
     // each layer in the neural network. The backward method computes the
     // gradients of the loss with respect to the parameters of the neural
     // network using the chain rule of calculus.
-    pub fn backward(&mut self) {
+    fn backward(&mut self) -> () {
         let mut dLdA = self.loss.backward();
         let mut dLdZ = DMatrix::zeros(0,0);
         for i in (0..self.layers.len()).rev() {
@@ -84,5 +87,17 @@ impl NeuralNetwork {
             }
             dLdA = self.layers[i].backward(&dLdZ);
         }
+    }
+
+    fn get_layers(&self) -> Vec<Box<dyn Layer>>{
+        self.layers.clone()
+    }
+
+    fn get_activations(&self) -> Vec<Box<dyn ActivationFunction>>{
+        self.activations.clone()
+    }
+
+    fn get_loss(&self) -> Box<dyn LossFunction>{
+        self.loss.clone()
     }
 }

--- a/src/nn/model.rs
+++ b/src/nn/model.rs
@@ -23,41 +23,38 @@ use crate::nn::activation::ActivationFunction;
     * where each layer is a linear layer followed by an activation function.
 **/
 
-pub trait NeuralNetwork {
+pub trait NN {
     fn forward(&mut self, x : &DMatrix<f64>) -> DMatrix<f64>;
-    fn backward(&mut self) -> ();
+    fn backward(&mut self) -> DMatrix<f64>;
     fn get_layers(&self) -> Vec<Box<dyn Layer>>;
     fn get_activations(&self) -> Vec<Box<dyn ActivationFunction>>;
     fn get_loss(&self) -> Box<dyn LossFunction>;
 }
-pub struct SequentialNeuralNetwork {
+pub struct NeuralNetwork {
     pub layers: Vec<Box<dyn Layer>>,
     pub activations: Vec<Box<dyn ActivationFunction>>,
     pub loss: Box<dyn LossFunction>,
 }
 
-impl SequentialNeuralNetwork {
+impl NeuralNetwork {
     // Constructor for the NeuralNetwork struct. Creates a new NeuralNetwork
     // model with the specified layers and loss function.
     pub fn new(layers: Vec<Box<dyn Layer>>,
                activations: Vec<Box<dyn ActivationFunction>>,
                loss: Box<dyn LossFunction>) -> Self {
-    SequentialNeuralNetwork {
+        NeuralNetwork {
             layers: layers,
             activations: activations,
             loss: loss,
         }
     }
-}
-
-impl NeuralNetwork for SequentialNeuralNetwork {
 
 
     // During forward propagation, we apply a sequence of linear transformations
     // and activation functions to the input data x to obtain the output data y.
     // That is, y = fNN (x) = fL (fL-1 ( ... f2 (f1 (x)) ... )). The forward
     // method computes the output of the neural network given the input data x.
-    fn forward(&mut self, x: &DMatrix<f64>) -> DMatrix<f64> {
+    pub fn forward(&mut self, x: &DMatrix<f64>) -> DMatrix<f64> {
         let mut A = x.clone();
         for i in 0..self.layers.len() {
             A = self.layers[i].forward(&A);
@@ -78,7 +75,7 @@ impl NeuralNetwork for SequentialNeuralNetwork {
     // each layer in the neural network. The backward method computes the
     // gradients of the loss with respect to the parameters of the neural
     // network using the chain rule of calculus.
-    fn backward(&mut self) -> () {
+    pub fn backward(&mut self) {
         let mut dLdA = self.loss.backward();
         let mut dLdZ = DMatrix::zeros(0,0);
         for i in (0..self.layers.len()).rev() {
@@ -87,17 +84,5 @@ impl NeuralNetwork for SequentialNeuralNetwork {
             }
             dLdA = self.layers[i].backward(&dLdZ);
         }
-    }
-
-    fn get_layers(&self) -> Vec<Box<dyn Layer>>{
-        self.layers.clone()
-    }
-
-    fn get_activations(&self) -> Vec<Box<dyn ActivationFunction>>{
-        self.activations.clone()
-    }
-
-    fn get_loss(&self) -> Box<dyn LossFunction>{
-        self.loss.clone()
     }
 }

--- a/src/nn/model.rs
+++ b/src/nn/model.rs
@@ -1,5 +1,5 @@
-use nalgebra::{DMatrix};
-use crate::nn::layers::Linear;
+use nalgebra::DMatrix;
+use crate::nn::layers::Layer;
 use crate::nn::loss::LossFunction;
 use crate::nn::activation::ActivationFunction;
 
@@ -24,7 +24,7 @@ use crate::nn::activation::ActivationFunction;
 **/
 
 pub struct NeuralNetwork {
-    pub layers: Vec<Box<Linear>>,
+    pub layers: Vec<Box<dyn Layer>>,
     pub activations: Vec<Box<dyn ActivationFunction>>,
     pub loss: Box<dyn LossFunction>,
 }
@@ -32,7 +32,7 @@ pub struct NeuralNetwork {
 impl NeuralNetwork {
     // Constructor for the NeuralNetwork struct. Creates a new NeuralNetwork
     // model with the specified layers and loss function.
-    pub fn new(layers: Vec<Box<Linear>>,
+    pub fn new(layers: Vec<Box<dyn Layer>>,
                activations: Vec<Box<dyn ActivationFunction>>,
                loss: Box<dyn LossFunction>) -> Self {
         NeuralNetwork {

--- a/src/nn/model.rs
+++ b/src/nn/model.rs
@@ -23,6 +23,13 @@ use crate::nn::activation::ActivationFunction;
     * where each layer is a linear layer followed by an activation function.
 **/
 
+pub trait NN {
+    fn forward(&mut self, x : &DMatrix<f64>) -> DMatrix<f64>;
+    fn backward(&mut self) -> DMatrix<f64>;
+    fn get_layers(&self) -> Vec<Box<dyn Layer>>;
+    fn get_activations(&self) -> Vec<Box<dyn ActivationFunction>>;
+    fn get_loss(&self) -> Box<dyn LossFunction>;
+}
 pub struct NeuralNetwork {
     pub layers: Vec<Box<dyn Layer>>,
     pub activations: Vec<Box<dyn ActivationFunction>>,

--- a/src/nn/model.rs
+++ b/src/nn/model.rs
@@ -23,38 +23,41 @@ use crate::nn::activation::ActivationFunction;
     * where each layer is a linear layer followed by an activation function.
 **/
 
-pub trait NN {
+pub trait NeuralNetwork {
     fn forward(&mut self, x : &DMatrix<f64>) -> DMatrix<f64>;
-    fn backward(&mut self) -> DMatrix<f64>;
+    fn backward(&mut self) -> ();
     fn get_layers(&self) -> Vec<Box<dyn Layer>>;
     fn get_activations(&self) -> Vec<Box<dyn ActivationFunction>>;
     fn get_loss(&self) -> Box<dyn LossFunction>;
 }
-pub struct NeuralNetwork {
+pub struct SequentialNeuralNetwork {
     pub layers: Vec<Box<dyn Layer>>,
     pub activations: Vec<Box<dyn ActivationFunction>>,
     pub loss: Box<dyn LossFunction>,
 }
 
-impl NeuralNetwork {
+impl SequentialNeuralNetwork {
     // Constructor for the NeuralNetwork struct. Creates a new NeuralNetwork
     // model with the specified layers and loss function.
     pub fn new(layers: Vec<Box<dyn Layer>>,
                activations: Vec<Box<dyn ActivationFunction>>,
                loss: Box<dyn LossFunction>) -> Self {
-        NeuralNetwork {
+    SequentialNeuralNetwork {
             layers: layers,
             activations: activations,
             loss: loss,
         }
     }
+}
+
+impl NeuralNetwork for SequentialNeuralNetwork {
 
 
     // During forward propagation, we apply a sequence of linear transformations
     // and activation functions to the input data x to obtain the output data y.
     // That is, y = fNN (x) = fL (fL-1 ( ... f2 (f1 (x)) ... )). The forward
     // method computes the output of the neural network given the input data x.
-    pub fn forward(&mut self, x: &DMatrix<f64>) -> DMatrix<f64> {
+    fn forward(&mut self, x: &DMatrix<f64>) -> DMatrix<f64> {
         let mut A = x.clone();
         for i in 0..self.layers.len() {
             A = self.layers[i].forward(&A);
@@ -75,7 +78,7 @@ impl NeuralNetwork {
     // each layer in the neural network. The backward method computes the
     // gradients of the loss with respect to the parameters of the neural
     // network using the chain rule of calculus.
-    pub fn backward(&mut self) {
+    fn backward(&mut self) -> () {
         let mut dLdA = self.loss.backward();
         let mut dLdZ = DMatrix::zeros(0,0);
         for i in (0..self.layers.len()).rev() {
@@ -84,5 +87,17 @@ impl NeuralNetwork {
             }
             dLdA = self.layers[i].backward(&dLdZ);
         }
+    }
+
+    fn get_layers(&self) -> Vec<Box<dyn Layer>>{
+        self.layers.clone()
+    }
+
+    fn get_activations(&self) -> Vec<Box<dyn ActivationFunction>>{
+        self.activations.clone()
+    }
+
+    fn get_loss(&self) -> Box<dyn LossFunction>{
+        self.loss.clone()
     }
 }

--- a/src/optim/sgd.rs
+++ b/src/optim/sgd.rs
@@ -1,5 +1,5 @@
 use nalgebra::DMatrix;
-use crate::nn::model::{NeuralNetwork, SequentialNeuralNetwork};
+use crate::nn::model::NeuralNetwork;
 
 
 /**
@@ -18,7 +18,7 @@ use crate::nn::model::{NeuralNetwork, SequentialNeuralNetwork};
 
 
 pub struct SGD {
-    pub model: SequentialNeuralNetwork,
+    pub model: NeuralNetwork,
     pub lr: f64, // Learning Rate
     pub mu: f64, // Momentum
     pub v_W: Vec<DMatrix<f64>>, // Velocity for weights
@@ -28,7 +28,7 @@ pub struct SGD {
 impl SGD {
     // Constructor for the SGD struct. Creates a new SGD optimizer with
     // the specified learning rate and momentum.
-    pub fn new(model: SequentialNeuralNetwork, lr: f64, mu: f64) -> Self {
+    pub fn new(model: NeuralNetwork, lr: f64, mu: f64) -> Self {
         let mut v_W = Vec::new();
         let mut v_b = Vec::new();
         for i in 0..model.layers.len() {

--- a/src/optim/sgd.rs
+++ b/src/optim/sgd.rs
@@ -1,5 +1,5 @@
 use nalgebra::DMatrix;
-use crate::nn::model::NeuralNetwork;
+use crate::nn::model::{NeuralNetwork, SequentialNeuralNetwork};
 
 
 /**
@@ -18,7 +18,7 @@ use crate::nn::model::NeuralNetwork;
 
 
 pub struct SGD {
-    pub model: NeuralNetwork,
+    pub model: SequentialNeuralNetwork,
     pub lr: f64, // Learning Rate
     pub mu: f64, // Momentum
     pub v_W: Vec<DMatrix<f64>>, // Velocity for weights
@@ -28,8 +28,8 @@ pub struct SGD {
 impl SGD {
     // Constructor for the SGD struct. Creates a new SGD optimizer with
     // the specified learning rate and momentum.
-    pub fn new(model: NeuralNetwork, lr: f64, mu: f64) -> Self {
-        let mut v_W = Vec::new();
+    pub fn new(model: SequentialNeuralNetwork, lr: f64, mu: f64) -> Self {
+        let mut v_W: Vec<nalgebra::Matrix<f64, nalgebra::Dyn, nalgebra::Dyn, nalgebra::VecStorage<f64, nalgebra::Dyn, nalgebra::Dyn>>> = Vec::new();
         let mut v_b = Vec::new();
         for i in 0..model.layers.len() {
             v_W.push(DMatrix::zeros(model.layers[i].get_weights().nrows(), model.layers[i].get_weights().ncols()));

--- a/src/optim/sgd.rs
+++ b/src/optim/sgd.rs
@@ -1,5 +1,5 @@
 use nalgebra::DMatrix;
-use crate::nn::model::NeuralNetwork;
+use crate::nn::model::{NeuralNetwork, SequentialNeuralNetwork};
 
 
 /**
@@ -18,7 +18,7 @@ use crate::nn::model::NeuralNetwork;
 
 
 pub struct SGD {
-    pub model: NeuralNetwork,
+    pub model: SequentialNeuralNetwork,
     pub lr: f64, // Learning Rate
     pub mu: f64, // Momentum
     pub v_W: Vec<DMatrix<f64>>, // Velocity for weights
@@ -28,7 +28,7 @@ pub struct SGD {
 impl SGD {
     // Constructor for the SGD struct. Creates a new SGD optimizer with
     // the specified learning rate and momentum.
-    pub fn new(model: NeuralNetwork, lr: f64, mu: f64) -> Self {
+    pub fn new(model: SequentialNeuralNetwork, lr: f64, mu: f64) -> Self {
         let mut v_W = Vec::new();
         let mut v_b = Vec::new();
         for i in 0..model.layers.len() {


### PR DESCRIPTION
Currently, the codebase's implementation of NeuralNetworks was not generic and instead had to be specified for each child class individually. 

I modified Model.rs to create a NeuralNetwork trait consisting of forward/backward functions, and three attributes: generic vectors of loss, activation functions, and layers. 

When we approach the implementation of more layers and more models such as CNN and RNN, we can use the class's modularity to create an out-of-the-box CNN/RNN. 

Resolves #6 